### PR TITLE
Fix stackoverflow and email link

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,8 @@ To read more about app settings, check [Click here](https://github.com/CloudBoos
 
 - Report bugs and feature requests on [GitHub issue tracker](https://github.com/CloudBoost/cloudboost/issues). 
 - You can reach out to us on [Slack](https://slack.cloudboost.io). All of our engineers hangout here. 
-- [StackOverflow](stackoverflow.com/questions/tagged/cloudboost) : Tag your questions with `cloudboost` tag, so that we're notified.
-- Email: [support@cloudboost.io](support@cloudboost.io)
+- [StackOverflow](//stackoverflow.com/questions/tagged/cloudboost) : Tag your questions with `cloudboost` tag, so that we're notified.
+- Email: [support@cloudboost.io](mailto:support@cloudboost.io)
 - Twitter: [@cloudboostio](https://twitter.com/cloudboostio)
 
 # Tests


### PR DESCRIPTION
Stackoverflow link was not provided correctly and email link is updated to open default email application